### PR TITLE
fix: get correct source string to parse

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,7 +27,7 @@
  */
 
 export const NAME = 'style9';
-export const SERIALIZE_COMPRESSION_FLAG = '#';
+export const SERIALIZE_COMPRESSION_FLAG = '__SECRET_SERIALIZE_COMPRESSION_FLAG_DO_NOT_USE_OR_YOU_WILL_BE_FIRED__';
 
 // https://github.com/necolas/react-native-web/blob/36dacb2052efdab2a28655773dc76934157d9134/packages/react-native-web/src/modules/unitlessNumbers/index
 export const UNITLESS_NUMBERS = [

--- a/src/lib/deserialize-css.ts
+++ b/src/lib/deserialize-css.ts
@@ -5,9 +5,9 @@ import { SERIALIZE_COMPRESSION_FLAG } from './constants';
 const unzip = promisify(gunzip);
 
 export async function deserializeCss(source: string) {
-  if (source.includes(SERIALIZE_COMPRESSION_FLAG)) {
+  if (source.startsWith(SERIALIZE_COMPRESSION_FLAG)) {
     const decompressedSource = await unzip(
-      Buffer.from(source.replace(SERIALIZE_COMPRESSION_FLAG, ''), 'base64')
+      Buffer.from(source.substring(SERIALIZE_COMPRESSION_FLAG.length), 'base64')
     );
 
     return decompressedSource.toString('utf-8');

--- a/src/next-appdir/index.ts
+++ b/src/next-appdir/index.ts
@@ -145,9 +145,8 @@ module.exports = (pluginOptions = {}) => (nextConfig: NextConfig = {}) => {
 
       // For some reason, Next 11.0.1 has `config.optimization.splitChunks`
       // set to `false` when webpack 5 is enabled.
-      config.optimization.splitChunks = config.optimization.splitChunks || {
-        cacheGroups: {}
-      };
+      config.optimization.splitChunks ||= {};
+      config.optimization.splitChunks.cacheGroups ||= {};
 
       const MiniCssExtractPlugin = getNextMiniCssExtractPlugin(ctx.dev);
 

--- a/src/next.ts
+++ b/src/next.ts
@@ -185,6 +185,9 @@ module.exports = (pluginOptions = {}) => (nextConfig: NextConfig = {}) => {
       });
 
       if (outputCSS) {
+        config.optimization.splitChunks ||= {};
+        config.optimization.splitChunks.cacheGroups ||= {};
+
         config.optimization.splitChunks.cacheGroups.style9 = {
           name: 'style9',
           // We apply cacheGroups to style9 virtual css only


### PR DESCRIPTION
This PR fixed 2 small issues: 

1) The 'next build' command would throw the following error:

```bash
TypeError: Cannot set properties of undefined (setting 'style9')
    at Object.webpack (./elegant-cloud-zckzqc/node_modules/style9-webpack/dist/next-appdir/index.js:135:72)
    at Object.getBaseWebpackConfig [as default] (./elegant-cloud-zckzqc/node_modules/next/dist/build/webpack-config.js:1441:32)
```
2) When a CSS source string is larger than 1000 symbols webpack cannot parse a decoded source string:

```js
../../../node_modules/.pnpm/style9-webpack@0.3.2_cpomobmqywdxnehg4vsfb6qrc4/node_modules/style9-webpack/dist/next-appdir/virtual.next.style9.css.webpack[javascript/auto]!=!../../../node_modules/.pnpm/next@13.1.6_kgpnzzej6jhkidcwkphtiabcee/node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[3].oneOf[0].use[1]!../../../node_modules/.pnpm/next@13.1.6_kgpnzzej6jhkidcwkphtiabcee/node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[3].oneOf[0].use[2]!../../../node_modules/.pnpm/style9-webpack@0.3.2_cpomobmqywdxnehg4vsfb6qrc4/node_modules/style9-webpack/dist/next-appdir/style9-next-virtual-loader.js!../../../node_modules/.pnpm/style9-webpack@0.3.2_cpomobmqywdxnehg4vsfb6qrc4/node_modules/style9-webpack/dist/next-appdir/virtual.next.style9.css?{"fileName":"./pkgs/ds-atoms/s-button/src/Button.ZuamrsM.style9.css","source":"
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
```