### PR TITLE
feat(next): add option to override rule options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "style9-webpack",
-  "version": "0.1.5",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "style9-webpack",
-      "version": "0.1.5",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.12",

--- a/src/next-appdir/index.ts
+++ b/src/next-appdir/index.ts
@@ -9,6 +9,11 @@ import type { NextConfig, WebpackConfigContext } from 'next/dist/server/config-s
 import Style9Plugin from '../index';
 import type webpack from 'webpack';
 
+interface RuleOptions {
+  test?: webpack.RuleSetCondition;
+  exclude?: webpack.RuleSetCondition;
+}
+
 /** Next.js' precompilation add "__esModule: true", but doesn't add an actual default exports */
 // @ts-expect-error -- Next.js fucks something up
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- Next.js fucks something up
@@ -104,7 +109,11 @@ function getStyle9VirtualCssLoader(options: WebpackConfigContext, MiniCssExtract
   return loaders;
 }
 
-module.exports = (pluginOptions = {}) => (nextConfig: NextConfig = {}) => {
+module.exports = (pluginOptions = {}, ruleOptions: RuleOptions = {}) => (nextConfig: NextConfig = {}) => {
+  const {
+    test = /\.(tsx|ts|js|mjs|jsx)$/,
+    exclude = /node_modules/
+  } = ruleOptions;
   return {
     ...nextConfig,
     webpack(config: any, ctx: WebpackConfigContext) {
@@ -151,8 +160,8 @@ module.exports = (pluginOptions = {}) => (nextConfig: NextConfig = {}) => {
       const MiniCssExtractPlugin = getNextMiniCssExtractPlugin(ctx.dev);
 
       config.module.rules.push({
-        test: /\.(tsx|ts|js|mjs|jsx)$/,
-        exclude: /node_modules/,
+        test,
+        exclude,
         use: [
           {
             loader: require.resolve('./style9-next-loader'),

--- a/src/next.ts
+++ b/src/next.ts
@@ -9,6 +9,11 @@ import type { NextConfig, WebpackConfigContext } from 'next/dist/server/config-s
 import Style9Plugin from './index';
 import type webpack from 'webpack';
 
+interface RuleOptions {
+  test?: webpack.RuleSetCondition;
+  exclude?: webpack.RuleSetCondition;
+}
+
 /** Next.js' precompilation add "__esModule: true", but doesn't add an actual default exports */
 // @ts-expect-error -- Next.js fucks something up
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- Next.js fucks something up
@@ -100,7 +105,11 @@ function getStyle9VirtualCssLoader(options: WebpackConfigContext, MiniCssExtract
   return loaders;
 }
 
-module.exports = (pluginOptions = {}) => (nextConfig: NextConfig = {}) => {
+module.exports = (pluginOptions = {}, ruleOptions: RuleOptions = {}) => (nextConfig: NextConfig = {}) => {
+  const {
+    test = /\.(tsx|ts|js|mjs|jsx)$/,
+    exclude = /node_modules/
+  } = ruleOptions;
   return {
     ...nextConfig,
     webpack(config: any, ctx: WebpackConfigContext) {
@@ -153,8 +162,8 @@ module.exports = (pluginOptions = {}) => (nextConfig: NextConfig = {}) => {
       const MiniCssExtractPlugin = getNextMiniCssExtractPlugin(ctx.dev);
 
       config.module.rules.push({
-        test: /\.(tsx|ts|js|mjs|jsx)$/,
-        exclude: /node_modules/,
+        test,
+        exclude,
         use: [
           {
             loader: Style9Plugin.loader,


### PR DESCRIPTION
This PR adds an option to override the `test` and `exclude` options used in the Webpack module rule created by the Next plugins (both the app dir plugin and the regular one). It does so by adding a second, optional `ruleOptions` arg to the plugin(s).

The override is optional and falls back to the current defaults.

I think this is useful, for example in cases where shared design-system packages are are built with Style9 and distributed as npm packages or shared inside a monorepo.

The current behavior, which excludes files inside `node_modules` is a good default, but can prevent the plugin from being useful in some cases, which will then require monkey-patching.

This does add some some API surface, but it designed to be optional and falls back to the defaults so shouldn't affect users that don't require the escape hatch.